### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -9,6 +9,9 @@
 name: R-hub
 run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/m-path-io/mpathr/security/code-scanning/6](https://github.com/m-path-io/mpathr/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, as they primarily involve reading repository contents and interacting with external services using secrets. If any specific steps require additional permissions, they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
