### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -5,6 +5,9 @@ on:
     types: [created]
 
 name: Commands
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   document:


### PR DESCRIPTION
Potential fix for [https://github.com/m-path-io/mpathr/security/code-scanning/5](https://github.com/m-path-io/mpathr/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define minimal permissions for all jobs. Since the workflow involves checking out the repository, fetching pull requests, and pushing changes, we will grant `contents: write` and `pull-requests: write` permissions. These permissions are sufficient for the tasks performed in the workflow while avoiding unnecessary access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
