### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,6 +13,8 @@ on:
     branches: [main, master]
 
 name: R-CMD-check-hard
+permissions:
+  contents: read
 
 jobs:
   R-CMD-check:


### PR DESCRIPTION
Potential fix for [https://github.com/m-path-io/mpathr/security/code-scanning/1](https://github.com/m-path-io/mpathr/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
